### PR TITLE
[Feat] Question 및 InterviewResult API 구현

### DIFF
--- a/server/spring/src/main/java/com/example/skaxis/interviewresult/controller/InterviewResultController.java
+++ b/server/spring/src/main/java/com/example/skaxis/interviewresult/controller/InterviewResultController.java
@@ -1,0 +1,75 @@
+package com.example.skaxis.interviewresult.controller;
+
+import com.example.skaxis.interviewresult.dto.CommentUpdateRequest;
+import com.example.skaxis.interviewresult.model.InterviewResult;
+import com.example.skaxis.interviewresult.service.InterviewResultService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1")
+public class InterviewResultController {
+
+    private final InterviewResultService interviewResultService;
+
+    @Autowired
+    public InterviewResultController(InterviewResultService interviewResultService) {
+        this.interviewResultService = interviewResultService;
+    }
+
+    @GetMapping("/interview/{interview_id}/{interviewee_id}/download")
+    public ResponseEntity<Resource> downloadFile(
+            @PathVariable("interview_id") Long interviewId,
+            @PathVariable("interviewee_id") Long intervieweeId,
+            @RequestParam("type") String fileType) {
+        
+        Resource file = interviewResultService.downloadFile(interviewId, intervieweeId, fileType);
+        
+        String contentType;
+        String filename;
+        
+        switch (fileType.toLowerCase()) {
+            case "pdf":
+                contentType = MediaType.APPLICATION_PDF_VALUE;
+                filename = "interview_" + interviewId + "_" + intervieweeId + ".pdf";
+                break;
+            case "excel":
+                contentType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+                filename = "interview_" + interviewId + "_" + intervieweeId + ".xlsx";
+                break;
+            case "txt":
+                contentType = MediaType.TEXT_PLAIN_VALUE;
+                filename = "interview_" + interviewId + "_" + intervieweeId + ".txt";
+                break;
+            default:
+                contentType = MediaType.APPLICATION_OCTET_STREAM_VALUE;
+                filename = "interview_" + interviewId + "_" + intervieweeId;
+        }
+        
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType(contentType))
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + filename + "\"")
+                .body(file);
+    }
+
+    @PutMapping("/interview/{interview_id}/{interviewee_id}/comment")
+    public ResponseEntity<Map<String, String>> updateComment(
+            @PathVariable("interview_id") Long interviewId,
+            @PathVariable("interviewee_id") Long intervieweeId,
+            @RequestBody CommentUpdateRequest request) {
+        
+        InterviewResult result = interviewResultService.updateComment(interviewId, intervieweeId, request);
+        
+        Map<String, String> response = new HashMap<>();
+        response.put("result", "updated");
+        
+        return ResponseEntity.ok(response);
+    }
+}

--- a/server/spring/src/main/java/com/example/skaxis/interviewresult/dto/CommentUpdateRequest.java
+++ b/server/spring/src/main/java/com/example/skaxis/interviewresult/dto/CommentUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.example.skaxis.interviewresult.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentUpdateRequest {
+    private String comment;
+}

--- a/server/spring/src/main/java/com/example/skaxis/interviewresult/model/InterviewResult.java
+++ b/server/spring/src/main/java/com/example/skaxis/interviewresult/model/InterviewResult.java
@@ -1,0 +1,55 @@
+package com.example.skaxis.interviewresult.model;
+
+import com.example.skaxis.interview.model.Interview;
+import com.example.skaxis.interviewee.model.Interviewee;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "interview_result")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class InterviewResult {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "result_id")
+    private Long resultId;
+    
+    @Column(name = "interview_id", nullable = false)
+    private Long interviewId;
+    
+    @Column(name = "interviewee_id", nullable = false)
+    private Long intervieweeId;
+    
+    @Column(name = "score")
+    private Integer score;
+    
+    @Column(name = "comment", columnDefinition = "TEXT")
+    private String comment;
+    
+    @Column(name = "pdf_path")
+    private String pdfPath;
+    
+    @Column(name = "excel_path")
+    private String excelPath;
+    
+    @Column(name = "stt_path")
+    private String sttPath;
+    
+    // 면접과의 관계
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "interview_id", insertable = false, updatable = false)
+    private Interview interview;
+    
+    // 지원자와의 관계
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "interviewee_id", insertable = false, updatable = false)
+    private Interviewee interviewee;
+}

--- a/server/spring/src/main/java/com/example/skaxis/interviewresult/repository/InterviewResultRepository.java
+++ b/server/spring/src/main/java/com/example/skaxis/interviewresult/repository/InterviewResultRepository.java
@@ -1,0 +1,12 @@
+package com.example.skaxis.interviewresult.repository;
+
+import com.example.skaxis.interviewresult.model.InterviewResult;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface InterviewResultRepository extends JpaRepository<InterviewResult, Long> {
+    Optional<InterviewResult> findByInterviewIdAndIntervieweeId(Long interviewId, Long intervieweeId);
+}

--- a/server/spring/src/main/java/com/example/skaxis/interviewresult/service/InterviewResultService.java
+++ b/server/spring/src/main/java/com/example/skaxis/interviewresult/service/InterviewResultService.java
@@ -1,0 +1,79 @@
+package com.example.skaxis.interviewresult.service;
+
+import com.example.skaxis.interviewresult.dto.CommentUpdateRequest;
+import com.example.skaxis.interviewresult.model.InterviewResult;
+import com.example.skaxis.interviewresult.repository.InterviewResultRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.net.MalformedURLException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+@Service
+public class InterviewResultService {
+
+    private final InterviewResultRepository interviewResultRepository;
+    
+    @Value("${file.upload.path:./uploads}")
+    private String fileUploadPath;
+
+    @Autowired
+    public InterviewResultService(InterviewResultRepository interviewResultRepository) {
+        this.interviewResultRepository = interviewResultRepository;
+    }
+
+    public InterviewResult getInterviewResult(Long interviewId, Long intervieweeId) {
+        return interviewResultRepository.findByInterviewIdAndIntervieweeId(interviewId, intervieweeId)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        "면접 결과를 찾을 수 없습니다. 면접 ID: " + interviewId + ", 지원자 ID: " + intervieweeId));
+    }
+
+    @Transactional
+    public InterviewResult updateComment(Long interviewId, Long intervieweeId, CommentUpdateRequest request) {
+        InterviewResult result = getInterviewResult(interviewId, intervieweeId);
+        result.setComment(request.getComment());
+        return interviewResultRepository.save(result);
+    }
+
+    public Resource downloadFile(Long interviewId, Long intervieweeId, String fileType) {
+        InterviewResult result = getInterviewResult(interviewId, intervieweeId);
+        
+        String filePath;
+        switch (fileType.toLowerCase()) {
+            case "pdf":
+                filePath = result.getPdfPath();
+                break;
+            case "excel":
+                filePath = result.getExcelPath();
+                break;
+            case "txt":
+                filePath = result.getSttPath();
+                break;
+            default:
+                throw new IllegalArgumentException("지원하지 않는 파일 형식입니다: " + fileType);
+        }
+        
+        if (filePath == null || filePath.isEmpty()) {
+            throw new EntityNotFoundException("요청한 파일이 존재하지 않습니다.");
+        }
+        
+        try {
+            Path path = Paths.get(fileUploadPath).resolve(filePath).normalize();
+            Resource resource = new UrlResource(path.toUri());
+            
+            if (resource.exists()) {
+                return resource;
+            } else {
+                throw new EntityNotFoundException("파일을 찾을 수 없습니다: " + filePath);
+            }
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("파일 경로가 잘못되었습니다: " + filePath, e);
+        }
+    }
+}

--- a/server/spring/src/main/java/com/example/skaxis/question/controller/QuestionController.java
+++ b/server/spring/src/main/java/com/example/skaxis/question/controller/QuestionController.java
@@ -1,0 +1,51 @@
+package com.example.skaxis.question.controller;
+
+import com.example.skaxis.question.dto.QuestionCreateRequest;
+import com.example.skaxis.question.dto.QuestionUpdateRequest;
+import com.example.skaxis.question.model.Question;
+import com.example.skaxis.question.service.QuestionService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/questions")
+public class QuestionController {
+
+    private final QuestionService questionService;
+
+    @Autowired
+    public QuestionController(QuestionService questionService) {
+        this.questionService = questionService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<Question>> getAllQuestions(
+            @RequestParam(required = false) Long interview_id,
+            @RequestParam(required = false) String type) {
+        return ResponseEntity.ok(questionService.getAllQuestions(interview_id, type));
+    }
+
+    @PostMapping
+    public ResponseEntity<Question> createQuestion(@RequestBody QuestionCreateRequest request) {
+        Question createdQuestion = questionService.createQuestion(request);
+        return new ResponseEntity<>(createdQuestion, HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{question_id}")
+    public ResponseEntity<Question> updateQuestion(
+            @PathVariable("question_id") Long questionId,
+            @RequestBody QuestionUpdateRequest request) {
+        Question updatedQuestion = questionService.updateQuestion(questionId, request);
+        return ResponseEntity.ok(updatedQuestion);
+    }
+
+    @DeleteMapping("/{question_id}")
+    public ResponseEntity<Void> deleteQuestion(@PathVariable("question_id") Long questionId) {
+        questionService.deleteQuestion(questionId);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+}

--- a/server/spring/src/main/java/com/example/skaxis/question/dto/QuestionCreateRequest.java
+++ b/server/spring/src/main/java/com/example/skaxis/question/dto/QuestionCreateRequest.java
@@ -1,0 +1,16 @@
+package com.example.skaxis.question.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuestionCreateRequest {
+    private Long interview_id;
+    private String type;
+    private String content;
+}

--- a/server/spring/src/main/java/com/example/skaxis/question/dto/QuestionUpdateRequest.java
+++ b/server/spring/src/main/java/com/example/skaxis/question/dto/QuestionUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.example.skaxis.question.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuestionUpdateRequest {
+    private String type;
+    private String content;
+}

--- a/server/spring/src/main/java/com/example/skaxis/question/repository/QuestionRepository.java
+++ b/server/spring/src/main/java/com/example/skaxis/question/repository/QuestionRepository.java
@@ -1,0 +1,14 @@
+package com.example.skaxis.question.repository;
+
+import com.example.skaxis.question.model.Question;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+    List<Question> findByInterviewId(Long interviewId);
+    List<Question> findByType(String type);
+    List<Question> findByInterviewIdAndType(Long interviewId, String type);
+}

--- a/server/spring/src/main/java/com/example/skaxis/question/service/QuestionService.java
+++ b/server/spring/src/main/java/com/example/skaxis/question/service/QuestionService.java
@@ -1,0 +1,71 @@
+package com.example.skaxis.question.service;
+
+import com.example.skaxis.question.dto.QuestionCreateRequest;
+import com.example.skaxis.question.dto.QuestionUpdateRequest;
+import com.example.skaxis.question.model.Question;
+import com.example.skaxis.question.repository.QuestionRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class QuestionService {
+
+    private final QuestionRepository questionRepository;
+
+    @Autowired
+    public QuestionService(QuestionRepository questionRepository) {
+        this.questionRepository = questionRepository;
+    }
+
+    public List<Question> getAllQuestions(Long interviewId, String type) {
+        if (interviewId != null && type != null) {
+            return questionRepository.findByInterviewIdAndType(interviewId, type);
+        } else if (interviewId != null) {
+            return questionRepository.findByInterviewId(interviewId);
+        } else if (type != null) {
+            return questionRepository.findByType(type);
+        } else {
+            return questionRepository.findAll();
+        }
+    }
+
+    @Transactional
+    public Question createQuestion(QuestionCreateRequest request) {
+        Question question = Question.builder()
+                .interviewId(request.getInterview_id())
+                .type(request.getType())
+                .content(request.getContent())
+                .build();
+        
+        return questionRepository.save(question);
+    }
+
+    @Transactional
+    public Question updateQuestion(Long questionId, QuestionUpdateRequest request) {
+        Question question = questionRepository.findById(questionId)
+                .orElseThrow(() -> new EntityNotFoundException("질문을 찾을 수 없습니다. ID: " + questionId));
+        
+        if (request.getType() != null) {
+            question.setType(request.getType());
+        }
+        
+        if (request.getContent() != null) {
+            question.setContent(request.getContent());
+        }
+        
+        return questionRepository.save(question);
+    }
+
+    @Transactional
+    public void deleteQuestion(Long questionId) {
+        if (!questionRepository.existsById(questionId)) {
+            throw new EntityNotFoundException("질문을 찾을 수 없습니다. ID: " + questionId);
+        }
+        
+        questionRepository.deleteById(questionId);
+    }
+}


### PR DESCRIPTION
## 개요
면접 평가 시스템의 Question 및 InterviewResult 컴포넌트에 대한 API를 개발

## 주요 개발사항
### Question API (4개)
- `GET /api/v1/questions` - 면접 질문 목록 조회 (interview_id, type 필터링 지원)
- `POST /api/v1/questions` - 질문 등록
- `PUT /api/v1/questions/{question_id}` - 질문 수정
- `DELETE /api/v1/questions/{question_id}` - 질문 삭제

### InterviewResult API (2개)
- `GET /api/v1/interview/{interview_id}/{interviewee_id}/download` - 특정 면접 세션 내 지원자 결과 파일 다운로드 (PDF/Excel/TXT)
- `PUT /api/v1/interview/{interview_id}/{interviewee_id}/comment` - 특정 면접 세션 내 지원자별 평가 코멘트 입력/수정

## 구현 내용
1. **Question 컴포넌트**
   - DTO: QuestionCreateRequest, QuestionUpdateRequest 생성
   - 저장소: QuestionRepository 생성 (필터링 기능 포함)
   - 서비스: QuestionService 생성 (CRUD 기능 구현)
   - 컨트롤러: QuestionController 생성 (API 엔드포인트 구현)

2. **InterviewResult 컴포넌트**
   - 모델: InterviewResult 모델 생성 (면접 결과 정보 저장)
   - DTO: CommentUpdateRequest 생성
   - 저장소: InterviewResultRepository 생성
   - 서비스: InterviewResultService 생성 (파일 다운로드, 코멘트 업데이트 기능)
   - 컨트롤러: InterviewResultController 생성 (API 엔드포인트 구현)

## 테스트 방법
1. 질문 API 테스트:
   - 질문 목록 조회: `GET /api/v1/questions`
   - 질문 등록: `POST /api/v1/questions`
   - 질문 수정: `PUT /api/v1/questions/{question_id}`
   - 질문 삭제: `DELETE /api/v1/questions/{question_id}`

2. 면접 결과 API 테스트:
   - 결과 파일 다운로드: `GET /api/v1/interview/{interview_id}/{interviewee_id}/download?type=pdf`
   - 코멘트 업데이트: `PUT /api/v1/interview/{interview_id}/{interviewee_id}/comment`