### PR TITLE
[Refactor] 인증 API 경로 통일 및 표준화

### DIFF
--- a/server/spring/src/main/java/com/example/skaxis/auth/constants/AuthConstants.java
+++ b/server/spring/src/main/java/com/example/skaxis/auth/constants/AuthConstants.java
@@ -9,11 +9,11 @@ public final class AuthConstants {
     }
     //토큰 없이 허용된 URI목록
     public static final String[] PERMITTED_URI = {
-            "/signin",
-            "/signup/**",
-            "/reissue",
-             "/api/media/**",  // 미디어 업로드 API 허용
-             "/api/interviewees/**",
+            "/api/v1/auth/login",
+            "/api/v1/auth/signup/**",
+            "/api/v1/auth/reissue",
+            "/api/media/**",  // 미디어 업로드 API 허용
+            "/api/interviewees/**",
     };
     //admin user만 접근 가능한 URI
     public static final String[] ADMIN_URI = {

--- a/server/spring/src/main/java/com/example/skaxis/auth/controller/AuthController.java
+++ b/server/spring/src/main/java/com/example/skaxis/auth/controller/AuthController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 @Slf4j
 @RequiredArgsConstructor
 @RestController
+@RequestMapping("/api/v1/auth")
 public class AuthController {
     private final UserService userService;
     private final JWTUtil jwtUtil;

--- a/server/spring/src/main/java/com/example/skaxis/auth/filter/CustomLogoutFilter.java
+++ b/server/spring/src/main/java/com/example/skaxis/auth/filter/CustomLogoutFilter.java
@@ -26,7 +26,7 @@ public class CustomLogoutFilter extends GenericFilterBean {
     }
     private void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
         String requestUri = request.getRequestURI();
-        if(!requestUri.endsWith("/signout")){
+        if(!requestUri.endsWith("/api/v1/auth/logout")){
             filterChain.doFilter(request, response);
             return;
         }

--- a/server/spring/src/main/java/com/example/skaxis/auth/filter/LoginFilter.java
+++ b/server/spring/src/main/java/com/example/skaxis/auth/filter/LoginFilter.java
@@ -31,7 +31,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         this.authenticationManager = authenticationManager;
         this.jwtUtil = jwtUtil;
         this.objectMapper = objectMapper;
-        setFilterProcessesUrl("/signin");
+        setFilterProcessesUrl("/api/v1/auth/login");
     }
 
     @Override


### PR DESCRIPTION
# 인증 API 경로 통일 및 리팩토링

## 주요 변경사항
- 모든 인증 관련 API 경로를 API 명세서에 맞게 `/api/v1/auth/` 접두사로 통일
    - **로그인:** `/api/v1/auth/login`
    - **회원가입:** `/api/v1/auth/signup/**`
    - **토큰 재발급:** `/api/v1/auth/reissue`
    - **로그아웃:** `/api/v1/auth/logout`
- 컨트롤러, 필터, 상수 등에서 기존 경로(`/signin`, `/signup`, `/signout`, `/reissue`)를 모두 `/api/v1/auth/`로 변경
- 인증이 필요한 API 호출 시, JWT 토큰이 `Bearer` 타입으로 올바르게 전달되는지 테스트 완료

## 변경 목적
- 인증 API 경로의 일관성 및 RESTful 설계 원칙 준수
- 프론트엔드와 백엔드 간의 명확한 API 연동을 위한 표준화

## 테스트 내역
- 관리자 계정 회원가입 및 로그인 정상 동작 확인
- JWT 토큰을 이용한 인증 API 호출 성공
- 변경된 경로로 모든 인증 플로우 정상 작동 확인